### PR TITLE
Infinity Arrow Duplication Fix

### DIFF
--- a/src/VanillaEnchantments/handlers/Infinity.php
+++ b/src/VanillaEnchantments/handlers/Infinity.php
@@ -29,7 +29,6 @@ class Infinity extends VanillaEnchant implements Listener{
 			 if($arrow->getNameTag() == "infinity") {
 				 $event->setCancelled();
 			 }
-
 	}
 
 	/**
@@ -42,17 +41,15 @@ class Infinity extends VanillaEnchant implements Listener{
 		 	$arrow = $event->getProjectile();
 
 		 	if($event->isCancelled()){
-		  	 return;
+		  	    return;
 	   	}
 
 	   	if($bow->hasEnchantment(Enchantment::INFINITY)){
-				 $arrow->setNameTag("infinity");
+			$arrow->setNameTag("infinity");
 
-			   if($player instanceof Player and $player->isSurvival()){
-			       $player->getInventory()->addItem(Item::get(Item::ARROW, 0, 1));
-
-
-		   	 }
-	    }
+		        if($player instanceof Player and $player->isSurvival()){
+		            $player->getInventory()->addItem(Item::get(Item::ARROW, 0, 1));
+		  	}
+    		}
 	 }
 }

--- a/src/VanillaEnchantments/handlers/Infinity.php
+++ b/src/VanillaEnchantments/handlers/Infinity.php
@@ -9,29 +9,50 @@ use pocketmine\item\enchantment\Enchantment;
 
 use pocketmine\event\Listener;
 use pocketmine\event\entity\EntityShootBowEvent;
+use pocketmine\event\inventory\InventoryPickupArrowEvent;
 
 use VanillaEnchantments\Core;
 
 class Infinity extends VanillaEnchant implements Listener{
-	
+
 	public function __construct(Core $core){
 	    $core->getServer()->getPluginManager()->registerEvents($this, $core);
 	}
-	
+
+	/**
+	 * @param InventoryPickupArrowEvent $event
+	 */
+
+	public function cancelPickupArrow(InventoryPickupArrowEvent $event): void{
+			 $arrow = $event->getArrow();
+
+			 if($arrow->getNameTag() == "infinity") {
+				 $event->setCancelled();
+			 }
+
+	}
+
 	/**
 	 * @param EntityShootBowEvent $event
 	 */
-	
+
 	public function onShoot(EntityShootBowEvent $event): void{
-	      $player = $event->getEntity();
-	      $bow = $event->getBow();
-	      if($event->isCancelled()){
-		      return;
-		   }
+		 	$player = $event->getEntity();
+		 	$bow = $event->getBow();
+		 	$arrow = $event->getProjectile();
+
+		 	if($event->isCancelled()){
+		  	 return;
+	   	}
+
 	   	if($bow->hasEnchantment(Enchantment::INFINITY)){
+				 $arrow->setNameTag("infinity");
+
 			   if($player instanceof Player and $player->isSurvival()){
-			      $player->getInventory()->addItem(Item::get(Item::ARROW, 0, 1));
-		   	}
-	     }
+			       $player->getInventory()->addItem(Item::get(Item::ARROW, 0, 1));
+
+
+		   	 }
+	    }
 	 }
 }


### PR DESCRIPTION
When EntityShootBow event happens with the Infinity enchantment, the projectile will get the "infinity" nametag. If an InventoryPickupArrowEvent happens on a projectile with the "infinity" nametag, the InventoryPcikupArrowEvent will cancel. 