### PR TITLE
Rename glowstone_block to glowstone in config

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -12,7 +12,7 @@ fortune.blocks:
 - diamond_ore
 - leaves
 - nether_quartz_ore
-- glowstone_block
+- glowstone
 - redstone_ore
 - emerald_ore
 - glowing_redstone_ore


### PR DESCRIPTION
The ID of the glowstone block is glowstone not glowstone_block. For the item it's glowstone_dust.
https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/item/ItemIds.php#L117
https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/item/ItemIds.php#L369