### PR TITLE
Fix fortune enchantment

### DIFF
--- a/src/vanilla/Core.php
+++ b/src/vanilla/Core.php
@@ -115,7 +115,7 @@ class Core extends PluginBase implements Listener{
 				if($block->getId() == $it->getId()){
 					if(mt_rand(1, 99) <= 10 * $level){
 						if(empty($event->getDrops()) == false){
-							$event->setDrops(array_map(function(Item $drop){
+							$event->setDrops(array_map(function(Item $drop) use($add){
 								$drop->setCount($drop->getCount() + $add);
 								return $drop;
 							}, $event->getDrops()));


### PR DESCRIPTION
This PR fixes the fortune enchantment (bug reported in #79 and #82) by making the variable $add available in the function passed to array_map.